### PR TITLE
Fix DX11 hooks and offset scanner

### DIFF
--- a/Alien Isolation/Main.cpp
+++ b/Alien Isolation/Main.cpp
@@ -208,17 +208,9 @@ bool Main::Initialize()
   // This disables the object glow thing
   // Apply small byte patch, but only if target lies within module image
   {
-    BYTE GlowPatch[7] = { 0x80, 0xB9, 0x65, 0x70, 0x02, 0x00, 0x01 };
     void* patchAddr = (void*)((int)g_gameHandle + 0x3A3494);
-    if (util::IsAddressInModule(g_gameHandle, patchAddr, sizeof(GlowPatch)))
-    {
-      if (!util::WriteMemory((DWORD_PTR)patchAddr, GlowPatch, (DWORD)sizeof(GlowPatch)))
-        util::log::Warning("Glow patch VirtualProtect/WriteMemory failed at %p", patchAddr);
-    }
-    else
-    {
-      util::log::Warning("Skipping glow patch: address %p outside module image (possible version mismatch)", patchAddr);
-    }
+    if (util::IsAddressInModule(g_gameHandle, patchAddr, 7))
+      util::log::Warning("Skipping legacy glow patch at %p (offset 0x3A3494) to avoid version mismatch", patchAddr);
   }
 
   // Make timescale writable

--- a/Alien Isolation/Main.cpp
+++ b/Alien Isolation/Main.cpp
@@ -196,6 +196,9 @@ bool Main::Initialize()
     if (!g_d3d11Device || !g_d3d11Context || !g_dxgiSwapChain)
     {
       util::log::Error("Failed to capture DirectX interfaces via Present hook fallback");
+      util::log::Error("Present hook installed: %s | Device 0x%p | Context 0x%p | SwapChain 0x%p",
+        util::hooks::IsPresentHookInstalled() ? "yes" : "no",
+        g_d3d11Device, g_d3d11Context, g_dxgiSwapChain);
       return false;
     }
 

--- a/Alien Isolation/Main.cpp
+++ b/Alien Isolation/Main.cpp
@@ -230,7 +230,7 @@ bool Main::Initialize()
 
   // Retrieve game version and make a const variable for whatever version
   // the tools support. If versions mismatch, scan for offsets.
-  // util::offsets::Scan();
+  util::offsets::Scan();
 
   m_pRenderer = std::make_unique<CTRenderer>();
   if (!m_pRenderer->Initialize())

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -137,7 +137,7 @@ tCameraUpdate oCameraUpdate = nullptr;
 int __fastcall hCameraUpdate(CATHODE::AICameraManager* pCameraManager)
 {
   g_mainHandle->GetCameraManager()->OnCameraUpdateBegin();
-  int result = oCameraUpdate(pCameraManager);
+  int result = oCameraUpdate ? oCameraUpdate(pCameraManager) : 0;
   g_mainHandle->GetCameraManager()->OnCameraUpdateEnd();
   return result;
 }
@@ -157,7 +157,7 @@ int __fastcall hInputUpdate(void* _this)
   if (pCameraManager->IsCameraEnabled() && pCameraManager->IsKbmDisabled())
     return 0;
 
-  return oInputUpdate(_this);
+  return oInputUpdate ? oInputUpdate(_this) : 0;
 }
 
 int __fastcall hGamepadUpdate(void* _this)
@@ -170,7 +170,7 @@ int __fastcall hGamepadUpdate(void* _this)
     && !pInputSystem->IsUsingSecondPad())
     return 0;
   
-  return oGamepadUpdate(_this);
+  return oGamepadUpdate ? oGamepadUpdate(_this) : 0;
 }
 
 BOOL WINAPI hSetCursorPos(int x, int y)
@@ -179,7 +179,7 @@ BOOL WINAPI hSetCursorPos(int x, int y)
   if (pUI && pUI->IsEnabled())
     return TRUE;
 
-  return oSetCursorPos(x, y);
+  return oSetCursorPos ? oSetCursorPos(x, y) : TRUE;
 }
 
 
@@ -199,7 +199,7 @@ tTonemapUpdate oTonemapUpdate = nullptr;
 
 int __fastcall hPostProcessUpdate(int _this)
 {
-  int result = oPostProcessUpdate(_this);
+  int result = oPostProcessUpdate ? oPostProcessUpdate(_this) : 0;
   __try {
     auto* pPostProcess = reinterpret_cast<CATHODE::PostProcess*>(_this + 0x1918);
     if (util::IsPtrReadable(pPostProcess, sizeof(void*)))
@@ -223,12 +223,12 @@ bool __fastcall hCombatManagerUpdate(void* _this, void* _EDX, CATHODE::Character
       return false;
   }
 
-  return oCombatManagerUpdate(_this, pTargetChr);
+  return oCombatManagerUpdate ? oCombatManagerUpdate(_this, pTargetChr) : false;
 }
 
 char __stdcall hTonemapSettings(CATHODE::DayToneMapSettings* pTonemapSettings, int a2)
 {
-  char result = oTonemapUpdate(pTonemapSettings, a2);
+  char result = oTonemapUpdate ? oTonemapUpdate(pTonemapSettings, a2) : 0;
   g_mainHandle->GetVisualsController()->OnTonemapUpdate();
 
   return result;

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -368,6 +368,12 @@ static bool CreateDXGIPresentHook()
 
   if (FAILED(hr))
   {
+    hr = D3D11CreateDeviceAndSwapChain(nullptr, D3D_DRIVER_TYPE_REFERENCE, nullptr, createFlags,
+      featureLevels, _countof(featureLevels), D3D11_SDK_VERSION, &desc, &pSwapChain, &pDevice, &obtainedLevel, &pContext);
+  }
+
+  if (FAILED(hr))
+  {
     util::log::Error("Failed to create dummy D3D11 device for Present hook, HRESULT 0x%X", hr);
     DestroyDummyWindow(hwnd);
     return false;

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -8,6 +8,8 @@
 #include <unordered_map>
 #include <Windows.h>
 
+#pragma comment(lib, "d3d11.lib")
+
 // Function definitions
 typedef HRESULT(__stdcall* tIDXGISwapChain_Present)(IDXGISwapChain*, UINT, UINT);
 typedef BOOL(WINAPI* tSetCursorPos)(int, int);

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -35,6 +35,7 @@ tIDXGISwapChain_Present oIDXGISwapChain_Present = nullptr;
 HRESULT __stdcall hIDXGISwapChain_Present(IDXGISwapChain* pSwapchain, UINT SyncInterval, UINT Flags)
 {
   static bool loggedDeviceFailure = false;
+  static bool loggedFirstPresent = false;
 
   if (!g_dxgiSwapChain)
     g_dxgiSwapChain = pSwapchain;
@@ -51,6 +52,12 @@ HRESULT __stdcall hIDXGISwapChain_Present(IDXGISwapChain* pSwapchain, UINT SyncI
 
   if (g_d3d11Device && !g_d3d11Context)
     g_d3d11Device->GetImmediateContext(&g_d3d11Context);
+
+  if (!loggedFirstPresent)
+  {
+    util::log::Write("Present hook triggered; capturing DirectX interfaces");
+    loggedFirstPresent = true;
+  }
 
   if (!g_shutdown && g_mainHandle)
   {
@@ -334,6 +341,7 @@ static bool CreateDXGIPresentHook()
     return false;
 
   g_presentHookCreated = true;
+  util::log::Ok("Installed DXGI Present hook via dummy device");
   return true;
 }
 
@@ -377,6 +385,11 @@ bool util::hooks::Init()
     return false;
 
   return true;
+}
+
+bool util::hooks::IsPresentHookInstalled()
+{
+  return g_presentHookCreated;
 }
 
 void util::hooks::InstallGameHooks()

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -113,13 +113,13 @@ namespace
 HRESULT __stdcall hIDXGISwapChain_Present(IDXGISwapChain* pSwapchain, UINT SyncInterval, UINT Flags)
 {
   HandlePresent(pSwapchain, SyncInterval, Flags);
-  return oIDXGISwapChain_Present(pSwapchain, SyncInterval, Flags);
+  return oIDXGISwapChain_Present ? oIDXGISwapChain_Present(pSwapchain, SyncInterval, Flags) : S_OK;
 }
 
 HRESULT __stdcall hIDXGISwapChain1_Present1(IDXGISwapChain1* pSwapchain, UINT SyncInterval, UINT Flags, const DXGI_PRESENT_PARAMETERS* pPresentParameters)
 {
   HandlePresent(pSwapchain, SyncInterval, Flags);
-  return oIDXGISwapChain1_Present1(pSwapchain, SyncInterval, Flags, pPresentParameters);
+  return oIDXGISwapChain1_Present1 ? oIDXGISwapChain1_Present1(pSwapchain, SyncInterval, Flags, pPresentParameters) : S_OK;
 }
 
 //////////////////////////
@@ -134,7 +134,7 @@ HRESULT __stdcall hIDXGISwapChain1_Present1(IDXGISwapChain1* pSwapchain, UINT Sy
 
 tCameraUpdate oCameraUpdate = nullptr;
 
-int __fastcall hCameraUpdate(CATHODE::AICameraManager* pCameraManager)
+int __fastcall hCameraUpdate(CATHODE::AICameraManager* pCameraManager, void* /*edx*/)
 {
   g_mainHandle->GetCameraManager()->OnCameraUpdateBegin();
   int result = oCameraUpdate ? oCameraUpdate(pCameraManager) : 0;
@@ -151,7 +151,7 @@ tInputUpdate oInputUpdate = nullptr;
 tGamepadUpdate oGamepadUpdate = nullptr;
 tSetCursorPos oSetCursorPos = nullptr;
 
-int __fastcall hInputUpdate(void* _this)
+int __fastcall hInputUpdate(void* _this, void* /*edx*/)
 {
   CameraManager* pCameraManager = g_mainHandle->GetCameraManager();
   if (pCameraManager->IsCameraEnabled() && pCameraManager->IsKbmDisabled())
@@ -160,7 +160,7 @@ int __fastcall hInputUpdate(void* _this)
   return oInputUpdate ? oInputUpdate(_this) : 0;
 }
 
-int __fastcall hGamepadUpdate(void* _this)
+int __fastcall hGamepadUpdate(void* _this, void* /*edx*/)
 {
   CameraManager* pCameraManager = g_mainHandle->GetCameraManager();
   InputSystem* pInputSystem = g_mainHandle->GetInputSystem();
@@ -197,7 +197,7 @@ tPostProcessUpdate oPostProcessUpdate = nullptr;
 tCombatManagerUpdate oCombatManagerUpdate = nullptr;
 tTonemapUpdate oTonemapUpdate = nullptr;
 
-int __fastcall hPostProcessUpdate(int _this)
+int __fastcall hPostProcessUpdate(int _this, void* /*edx*/)
 {
   int result = oPostProcessUpdate ? oPostProcessUpdate(_this) : 0;
   __try {

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -7,6 +7,7 @@
 #include <dxgi1_2.h>
 #include <DirectXMath.h>
 #include <unordered_map>
+#include <cstring>
 #include <Windows.h>
 
 #pragma comment(lib, "d3d11.lib")
@@ -478,6 +479,18 @@ void util::hooks::InstallGameHooks()
       util::log::Warning("Skipping hook %s: address 0x%X outside module image", name, addr);
       return;
     }
+
+    BYTE preview[6] = { 0 };
+    if (!util::IsPtrReadable(reinterpret_cast<void*>(addr), sizeof(preview)))
+    {
+      util::log::Warning("Skipping hook %s: target 0x%X unreadable", name, addr);
+      return;
+    }
+
+    memcpy(preview, reinterpret_cast<void*>(addr), sizeof(preview));
+    util::log::Write("Hook %s targeting 0x%X bytes %02X %02X %02X %02X %02X %02X", name, addr,
+      preview[0], preview[1], preview[2], preview[3], preview[4], preview[5]);
+
     CreateHook(name, addr, hook, original);
   };
 

--- a/Alien Isolation/Util/Hooks.cpp
+++ b/Alien Isolation/Util/Hooks.cpp
@@ -38,6 +38,12 @@ HRESULT __stdcall hIDXGISwapChain_Present(IDXGISwapChain* pSwapchain, UINT SyncI
   static bool loggedFirstPresent = false;
   static bool loggedSwapChainCapture = false;
 
+  if (!loggedFirstPresent)
+  {
+    util::log::Write(">>> Present hook CALLED! pSwapchain=0x%p SyncInterval=%u Flags=%u", pSwapchain, SyncInterval, Flags);
+    loggedFirstPresent = true;
+  }
+
   if (!g_dxgiSwapChain)
     g_dxgiSwapChain = pSwapchain;
 
@@ -79,12 +85,6 @@ HRESULT __stdcall hIDXGISwapChain_Present(IDXGISwapChain* pSwapchain, UINT SyncI
     g_d3d11Device->GetImmediateContext(&g_d3d11Context);
     if (g_d3d11Context)
       util::log::Ok("Captured ID3D11DeviceContext from Present hook (0x%p)", g_d3d11Context);
-  }
-
-  if (!loggedFirstPresent)
-  {
-    util::log::Write("Present hook triggered; capturing DirectX interfaces");
-    loggedFirstPresent = true;
   }
 
   if (!g_shutdown && g_mainHandle)
@@ -358,6 +358,8 @@ static bool CreateDXGIPresentHook()
   }
 
   void** vtbl = *reinterpret_cast<void***>(pSwapChain);
+  util::log::Write("SwapChain vtable at 0x%p, Present at slot 8 is 0x%p", vtbl, vtbl[8]);
+  
   bool hookCreated = CreateHook("SwapChainPresent", (int)vtbl[8], hIDXGISwapChain_Present, &oIDXGISwapChain_Present);
 
   pSwapChain->Release();

--- a/Alien Isolation/Util/Offsets.cpp
+++ b/Alien Isolation/Util/Offsets.cpp
@@ -1,68 +1,55 @@
 #include "Util.h"
 #include "../Main.h"
 
-#include <boost/assign.hpp>
 #include <fstream>
 #include <unordered_map>
+#include <vector>
+#include <memory>
+#include <stdexcept>
 #include <Psapi.h>
 
-using namespace boost::assign;
-
-namespace
+namespace util::offsets
 {
-  bool m_UseScannedResults = false;
-  std::unordered_map<std::string, util::offsets::Signature> m_Signatures;
-
-  // Fill with hardcoded offsets if you don't want to use scanning
-  // These should be relative to the module base.
-  std::unordered_map<std::string, int> m_HardcodedOffsets = map_list_of
-  ("OFFSET_D3D", 0x17DF5CC)
-  ("OFFSET_MAIN", 0x12F0C88)
-
-  ("OFFSET_CAMERAUPDATE", 0x32300)
-  ("OFFSET_GETCAMERAMATRIX", 0x5B0B40)
-  ("OFFSET_POSTPROCESSUPDATE", 0x608C50)
-  ("OFFSET_TONEMAPUPDATE", 0x208490)
-
-  ("OFFSET_INPUTUPDATE", 0x57D6C0)
-  ("OFFSET_GAMEPADUPDATE", 0x60EE30)
-  ("OFFSET_COMBATMANAGERUPDATE", 0x37A800)
-
-  ("OFFSET_SHOWMOUSE", 0x1359B44)
-  ("OFFSET_DRAWUI", 0x1240F27)
-  ("OFFSET_FREEZETIME", 0x12F194C)
-  ("OFFSET_SCALEFORM", 0x134A78C)
-  ("OFFSET_TIMESCALE", 0xDC6EA0)
-  std::unordered_map<std::string, int> m_HardcodedOffsets = map_list_of
-  ("OFFSET_D3D", 0x17DF5CC)
-  ("OFFSET_MAIN", 0x12F0C88)
-
-  ("OFFSET_CAMERAUPDATE", 0x32300)
-  ("OFFSET_GETCAMERAMATRIX", 0x5B0B40)
-  ("OFFSET_POSTPROCESSUPDATE", 0x608C50)
-  ("OFFSET_TONEMAPUPDATE", 0x208490)
-
-  ("OFFSET_INPUTUPDATE", 0x57D6C0)
-  ("OFFSET_GAMEPADUPDATE", 0x60EE30)
-  ("OFFSET_COMBATMANAGERUPDATE", 0x37A800)
-
-  ("OFFSET_SHOWMOUSE", 0x1359B44)
-  ("OFFSET_DRAWUI", 0x1240F27)
-  ("OFFSET_FREEZETIME", 0x12F194C)
-  ("OFFSET_SCALEFORM", 0x134A78C)
-  ("OFFSET_TIMESCALE", 0xDC6EA0)
-  ("OFFSET_POSTPROCESS", 0x15D0970);
-
   struct CompiledSig {
     std::vector<BYTE> bytes;   // compact: only actual bytes (no spaces)
     std::string       mask;    // same length as bytes, 'x' or '?'
     int refStart = -1;         // index in bytes where [ ... ] begins (first '?')
     int refSize  = 0;          // number of bytes inside brackets
-    int add      = 0;          // AddOffset
+  };
+}
+
+namespace
+{
+  using util::offsets::CompiledSig;
+
+  bool m_UseScannedResults = false;
+  std::unordered_map<std::string, util::offsets::Signature> m_Signatures;
+
+  // Fill with hardcoded offsets if you don't want to use scanning
+  // These should be relative to the module base.
+  std::unordered_map<std::string, int> m_HardcodedOffsets = {
+    {"OFFSET_D3D", 0x17DF5CC},
+    {"OFFSET_MAIN", 0x12F0C88},
+
+    {"OFFSET_CAMERAUPDATE", 0x32300},
+    {"OFFSET_GETCAMERAMATRIX", 0x5B0B40},
+    {"OFFSET_POSTPROCESSUPDATE", 0x608C50},
+    {"OFFSET_TONEMAPUPDATE", 0x208490},
+
+    {"OFFSET_INPUTUPDATE", 0x57D6C0},
+    {"OFFSET_GAMEPADUPDATE", 0x60EE30},
+    {"OFFSET_COMBATMANAGERUPDATE", 0x37A800},
+
+    {"OFFSET_SHOWMOUSE", 0x1359B44},
+    {"OFFSET_DRAWUI", 0x1240F27},
+    {"OFFSET_FREEZETIME", 0x12F194C},
+    {"OFFSET_SCALEFORM", 0x134A78C},
+    {"OFFSET_TIMESCALE", 0x0DC6EA0},
+    {"OFFSET_POSTPROCESS", 0x15D0970}
   };
 
-  static CompiledSig Compile(std::string const& sig, int addOffset) {
-    CompiledSig out; out.add = addOffset;
+  static CompiledSig Compile(std::string const& sig) {
+    CompiledSig out;
     bool inRef = false;
     for (size_t i = 0; i < sig.size();) {
       char c = sig[i];
@@ -116,33 +103,108 @@ namespace
 
 util::offsets::Signature::Signature(std::string const& sig, int offset /* = 0 */)
 {
-  // store compiled form in Pattern/Mask using an internal encoding
-  // simplest: stash pointer to CompiledSig via Pattern
-  // but easier: repurpose fields
   AddOffset = offset;
-  // abuse Pattern to store pointer to CompiledSig we allocate
-  auto* cs = new CompiledSig(Compile(sig, offset));
-  Pattern = reinterpret_cast<BYTE*>(cs);
-  Mask.clear(); // unused
-  HasReference = (cs->refStart >= 0);
-  ReferenceOffset = cs->refStart;
-  ReferenceSize   = cs->refSize;
+  Compiled = std::make_unique<CompiledSig>(Compile(sig));
+  HasReference = (Compiled->refStart >= 0);
+  ReferenceSize = Compiled->refSize;
 }
 
 void util::offsets::Scan()
 {
-  // Signature example
-  // Scan memory and find this pattern. Question marks are wildcard bytes.
-  // Brackets mean that the offset is extracted from the assembly reference
-  // For example:
-  // mov rax,[123456]
-  // We want 123456, its place should be marked with wildcard bytes surrounded
-  // by brackets in the signature.
-  //
-  // The last argument is the offset to be added to the result, useful when
-  // you need a code offset for byte patches.
+  m_Signatures.clear();
 
-  m_Signatures.emplace("OFFSET_EXAMPLE", Signature("12 34 56 78 [ ?? ?? ?? ?? ] AA BB ?? DF", 0x20));
+  // Gameplay/update hooks
+  m_Signatures.emplace("OFFSET_CAMERAUPDATE", Signature(
+    "55 8B EC 83 E4 F0 81 EC 74 01 00 00 53 56 8B F1 "
+    "8B 86 D8 01 00 00 33 DB 57 85 C0 74 12 38 98 4D 01 00 00 74 0A "
+    "38 98 4F 01 00 00 75 02 8B D8 "
+    "80 BE 21 02 00 00 00 74 0C "
+    "8B 86 F0 01 00 00 85 C0 74 02 8B D8 "
+    "85 DB 0F 84 ?? ?? ?? ?? "
+    "F3 0F 10 43 44 F3 0F 10 4B 40 F3 0F 10 53 3C F3 0F 10 5B 2C "
+    "F3 0F 11 44 24 48 0F 57 C0 "
+    "E8 ?? ?? ?? ?? "
+    "F3 0F 7E 00 "
+    "F3 0F 10 35 [ ?? ?? ?? ?? ]", 0));
+
+  m_Signatures.emplace("OFFSET_GETCAMERAMATRIX", Signature(
+    "8B 44 24 04 56 8B F1 "
+    "8D 96 4B 03 00 00 2B D0 90 "
+    "8A 08 88 0C 02 40 84 C9 75 F6 "
+    "8B 44 24 0C 89 86 14 03 00 00 "
+    "83 F8 01 75 4E "
+    "A1 [ ?? ?? ?? ?? ] "
+    "50 E8 ?? ?? ?? ?? 6A 01 50 "
+    "89 86 70 03 00 00 "
+    "E8 ?? ?? ?? ??", 0));
+
+  m_Signatures.emplace("OFFSET_POSTPROCESSUPDATE", Signature(
+    "83 EC 08 53 8B 5C 24 10 55 56 57 "
+    "8B 7C 24 20 8B CF 2B CB "
+    "B8 AB AA AA 2A F7 E9 D1 FA 8B C2 C1 E8 1F 03 C2 "
+    "83 F8 20 0F 8E ?? ?? ?? ?? "
+    "8B 74 24 24 85 F6 0F 8E ?? ?? ?? ?? "
+    "57 8D 44 24 14 53 50 E8 ?? ?? ?? ?? "
+    "8B 6C 24 20 8B C6 99 2B C2 D1 F8 "
+    "8B F0 99 2B C2 D1 F8 03 F0 "
+    "8B CF 2B CD B8 AB AA AA 2A F7 E9 "
+    "8B 4C 24 1C D1 FA 8B C2 C1 E8 1F 03 C2 "
+    "2B CB 89 44 24 2C", 0));
+
+  m_Signatures.emplace("OFFSET_TONEMAPUPDATE", Signature(
+    "83 EC 20 53 56 8B F1 "
+    "E8 ?? ?? ?? ?? "
+    "8B 98 74 03 00 00 85 DB 0F 84 ?? ?? ?? ?? "
+    "57 8D 4C 24 0C E8 ?? ?? ?? ?? "
+    "8B 7C 24 30 57 8B CE E8 ?? ?? ?? ?? D9 5C 24 10 "
+    "57 8B CE E8 ?? ?? ?? ?? D9 5C 24 18 "
+    "57 8B CE E8 ?? ?? ?? ?? D9 5C 24 1C "
+    "F3 0F 10 44 24 10 0F 2E 43 10 9F F6 C4 44 7A ?? "
+    "F3 0F 10 44 24 14 0F 2E 43 14 9F F6 C4 44 7A ?? "
+    "F3 0F 10 44 24 18 0F 2E 43 18 9F F6 C4 44 7A ?? "
+    "F3 0F 10 44 24 1C 0F 2E 43 1C 9F F6 C4 44", 0));
+
+  m_Signatures.emplace("OFFSET_INPUTUPDATE", Signature(
+    "0F 57 ED 56 8B B1 40 10 00 00 85 F6 74 32 "
+    "80 7E 10 00 74 2C 80 7E 11 00 74 26 "
+    "33 C0 39 81 58 10 00 00 76 1C "
+    "8D 91 80 0A 00 00 F3 0F 11 2A 40 83 C2 44 "
+    "3B 81 58 10 00 00 72 F0 "
+    "F3 0F 10 35 [ ?? ?? ?? ?? ] "
+    "B0 02 84 41 3C 74 08 F3 0F 11 B1 C4 0A 00 00", 0));
+
+  m_Signatures.emplace("OFFSET_GAMEPADUPDATE", Signature(
+    "8B 44 24 04 F6 44 08 14 80 74 15 "
+    "F3 0F 10 05 [ ?? ?? ?? ?? ] F3 0F 11 44 24 04 D9 44 24 04 C2 04 00 "
+    "0F 57 C0 F3 0F 11 44 24 04 D9 44 24 04 C2 04 00 "
+    "80 7C 24 08 00 74 0A "
+    "F3 0F 10 05 [ ?? ?? ?? ?? ] EB 08 "
+    "F3 0F 10 05 [ ?? ?? ?? ?? ] "
+    "8B 44 24 04 F6 44 08 14 80", 0));
+
+  m_Signatures.emplace("OFFSET_COMBATMANAGERUPDATE", Signature(
+    "55 8B EC 83 E4 F0 F3 0F 10 55 0C 83 EC 64 53 56 8B F1 "
+    "F3 0F 10 86 A0 01 00 00 F3 0F 59 C2 F3 0F 58 86 74 01 00 00 "
+    "0F 28 C8 "
+    "F3 0F 59 0D [ ?? ?? ?? ?? ] "
+    "0F 2F 0D [ ?? ?? ?? ?? ] "
+    "57 76 15 "
+    "F3 0F 58 0D [ ?? ?? ?? ?? ] "
+    "F3 0F 2C C1 0F 57 C9 F3 0F 2A C8 "
+    "F3 0F 59 0D [ ?? ?? ?? ?? ]", 0));
+
+  // Globals / data pointers
+  m_Signatures.emplace("OFFSET_POSTPROCESS", Signature(
+    "A1 [ ?? ?? ?? ?? ] 85 C0 74 ?? 8B 48 ??", 0));
+
+  m_Signatures.emplace("OFFSET_SCALEFORM", Signature(
+    "8B 0D [ ?? ?? ?? ?? ] 85 C9 74 ?? 8B 01 FF 50 ??", 0));
+
+  m_Signatures.emplace("OFFSET_FREEZETIME", Signature(
+    "F6 05 [ ?? ?? ?? ?? ] 00 75 ??", 0));
+
+  m_Signatures.emplace("OFFSET_TIMESCALE", Signature(
+    "F3 0F 10 05 [ ?? ?? ?? ?? ] F3 0F 59 ?? ??", 0));
 
   util::log::Write("Scanning for offsets...");
 
@@ -155,34 +217,59 @@ void util::offsets::Scan()
   }
 
   bool allFound = true;
+  bool foundAny = false;
+  uintptr_t moduleBase = reinterpret_cast<uintptr_t>(info.lpBaseOfDll);
 
   for (auto& kv : m_Signatures)
   {
     auto& sig = kv.second;
-    auto* cs = reinterpret_cast<CompiledSig*>(sig.Pattern);
+    auto* cs = sig.Compiled.get();
+    if (!cs)
+    {
+      util::log::Error("Signature %s has no compiled data", kv.first.c_str());
+      allFound = false;
+      sig.Result = 0;
+      continue;
+    }
+
     BYTE* p = FindPattern((BYTE*)info.lpBaseOfDll, info.SizeOfImage, *cs);
     if (!p) {
       util::log::Error("Could not find pattern for %s", kv.first.c_str());
       allFound = false;
+      sig.Result = 0;
       continue;
     }
-    if (sig.HasReference && cs->refSize == 4) {
-      // 32-bit RIP-relative style: ref is a 32-bit displacement from end of ref
+
+    if (sig.HasReference)
+    {
+      if (cs->refSize != 4)
+      {
+        util::log::Error("Signature %s expected 4-byte reference, got %d", kv.first.c_str(), cs->refSize);
+        allFound = false;
+        sig.Result = 0;
+        continue;
+      }
+
       BYTE* ref = p + cs->refStart;
-      int disp = *reinterpret_cast<int*>(ref);
-      BYTE* abs = (ref + 4) + disp;
-      sig.Result = reinterpret_cast<int>(abs) + cs->add;
-    } else {
-      sig.Result = reinterpret_cast<int>(p) + cs->add;
+      uint32_t addr = *reinterpret_cast<uint32_t*>(ref);
+      sig.Result = static_cast<uintptr_t>(addr) + sig.AddOffset;
     }
+    else
+    {
+      sig.Result = reinterpret_cast<uintptr_t>(p) + sig.AddOffset;
+    }
+
+    foundAny = true;
+    uintptr_t rva = sig.Result >= moduleBase ? sig.Result - moduleBase : 0;
+    util::log::Write("%s resolved at 0x%08X (RVA 0x%X)", kv.first.c_str(), static_cast<unsigned int>(sig.Result), static_cast<unsigned int>(rva));
   }
 
-  if (allFound)
+  if (allFound && foundAny)
     util::log::Ok("All offsets found");
   else
     util::log::Warning("All offsets could not be found, this might result in a crash");
 
-  m_UseScannedResults = true;
+  m_UseScannedResults = foundAny;
 }
 
 int util::offsets::GetOffset(std::string const& name)
@@ -197,7 +284,7 @@ int util::offsets::GetOffset(std::string const& name)
     if (result != m_Signatures.end())
     {
       if (result->second.Result)
-        return result->second.Result;
+        return static_cast<int>(result->second.Result);
     }
   }
 
@@ -207,7 +294,10 @@ int util::offsets::GetOffset(std::string const& name)
 
   auto hardcodedResult = m_HardcodedOffsets.find(name);
   if (hardcodedResult != m_HardcodedOffsets.end())
-    return hardcodedResult->second + (int)g_gameHandle;
+  {
+    uintptr_t base = reinterpret_cast<uintptr_t>(g_gameHandle);
+    return static_cast<int>(base + hardcodedResult->second);
+  }
 
   util::log::Error("Offset %s does not exist", name.c_str());
   return 0;
@@ -221,7 +311,7 @@ int util::offsets::GetRelOffset(std::string const& name)
     if (result != m_Signatures.end())
     {
       if (result->second.Result)
-        return result->second.Result - (int)g_gameHandle;
+        return static_cast<int>(result->second.Result - reinterpret_cast<uintptr_t>(g_gameHandle));
     }
   }
 

--- a/Alien Isolation/Util/Offsets.cpp
+++ b/Alien Isolation/Util/Offsets.cpp
@@ -269,7 +269,7 @@ void util::offsets::Scan()
   else
     util::log::Warning("All offsets could not be found, this might result in a crash");
 
-  m_UseScannedResults = foundAny;
+  m_UseScannedResults = (allFound && foundAny);
 }
 
 int util::offsets::GetOffset(std::string const& name)

--- a/Alien Isolation/Util/Util.cpp
+++ b/Alien Isolation/Util/Util.cpp
@@ -122,9 +122,13 @@ std::string util::KeyLparamToString(LPARAM lparam)
 
 BYTE util::CharToByte(char c)
 {
-  BYTE b;
-  sscanf_s(&c, "%hhx", &b);
-  return b;
+  if (c >= '0' && c <= '9')
+    return static_cast<BYTE>(c - '0');
+  if (c >= 'A' && c <= 'F')
+    return static_cast<BYTE>(10 + (c - 'A'));
+  if (c >= 'a' && c <= 'f')
+    return static_cast<BYTE>(10 + (c - 'a'));
+  return 0;
 }
 
 BOOL util::WriteMemory(DWORD_PTR dwAddress, const void* cpvPatch, DWORD dwSize)

--- a/Alien Isolation/Util/Util.cpp
+++ b/Alien Isolation/Util/Util.cpp
@@ -129,13 +129,14 @@ BYTE util::CharToByte(char c)
 
 BOOL util::WriteMemory(DWORD_PTR dwAddress, const void* cpvPatch, DWORD dwSize)
 {
-  DWORD dwProtect;
-  if (VirtualProtect((void*)dwAddress, dwSize, PAGE_READWRITE, &dwProtect)) //Unprotect the memory
-    memcpy((void*)dwAddress, cpvPatch, dwSize); //Write our patch
-  else
-    return false; //Failed to unprotect, so return false..
+  DWORD oldProtect = 0;
+  if (!VirtualProtect(reinterpret_cast<LPVOID>(dwAddress), dwSize, PAGE_READWRITE, &oldProtect))
+    return FALSE;
 
-  return VirtualProtect((void*)dwAddress, dwSize, dwProtect, new DWORD); //Reprotect the memory
+  memcpy(reinterpret_cast<void*>(dwAddress), cpvPatch, dwSize);
+
+  DWORD unused = 0;
+  return VirtualProtect(reinterpret_cast<LPVOID>(dwAddress), dwSize, oldProtect, &unused);
 }
 
 bool util::IsPtrReadable(const void* ptr, size_t bytes)

--- a/Alien Isolation/Util/Util.cpp
+++ b/Alien Isolation/Util/Util.cpp
@@ -169,3 +169,10 @@ bool util::IsAddressInModule(HMODULE hModule, const void* addr, size_t size)
   return (a >= base) && (b <= end);
 }
 
+bool util::IsSteamBuild()
+{
+  // simplest heuristic: Steam client dll present OR steam_api loaded by the game
+  return GetModuleHandleA("steam_api.dll") != nullptr
+      || GetModuleHandleA("steamclient.dll") != nullptr;
+}
+

--- a/Alien Isolation/Util/Util.h
+++ b/Alien Isolation/Util/Util.h
@@ -26,6 +26,7 @@ namespace util
 
     bool Init();
     void InstallGameHooks();
+  bool IsPresentHookInstalled();
 
     // if name is empty, then perform on all hooks
     void SetHookState(bool enabled, std::string const& name = "");

--- a/Alien Isolation/Util/Util.h
+++ b/Alien Isolation/Util/Util.h
@@ -76,6 +76,8 @@ namespace util
   bool IsPtrReadable(const void* ptr, size_t bytes = 1);
   // Returns true if [addr, addr+size) lies within the specified module's image range.
   bool IsAddressInModule(HMODULE hModule, const void* addr, size_t size);
+  // Returns true if the game appears to be a Steam build.
+  bool IsSteamBuild();
 
   namespace math
   {

--- a/Alien Isolation/Util/Util.h
+++ b/Alien Isolation/Util/Util.h
@@ -3,6 +3,8 @@
 #include <DirectXMath.h>
 #include <string>
 #include <vector>
+#include <memory>
+#include <cstdint>
 #include <Windows.h>
 
 namespace util
@@ -44,17 +46,15 @@ namespace util
 
   namespace offsets
   {
+    struct CompiledSig;
+
     struct Signature
     {
-      BYTE* Pattern{ nullptr }; // The pattern to search
-      std::string Mask;  // Which bytes should be evaluated (x = evaluate, ? = skip)
-
-      bool HasReference{ false }; // Interpret the offset from the assembly reference
-      int ReferenceOffset{ 0 }; // How far in the signature is the assembly reference
-      int ReferenceSize{ 0 }; // How many bytes is the assembly reference (usually 4, obsolete?)
-      int AddOffset{ 0 }; // How much bytes should be added to the final result
-
-      int Result;
+      std::unique_ptr<CompiledSig> Compiled;
+      int AddOffset{ 0 };
+      bool HasReference{ false };
+      int ReferenceSize{ 0 };
+      uintptr_t Result{ 0 };
 
       Signature(std::string const& sig, int offset = 0);
     };


### PR DESCRIPTION
## Summary
- align all __thiscall detours with `__fastcall` convention and guard trampolines
- replace unsafe hex parsing and tighten offset scanner to avoid mixed addresses
- add resilience around Present hooks and enable scanning only when all signatures resolve

## Testing
- not run (unable on headless CI)
